### PR TITLE
Modified ParserUtils to check whether {delimiter}{qualifer} combinati…

### DIFF
--- a/flatpack/src/main/java/net/sf/flatpack/util/ParserUtils.java
+++ b/flatpack/src/main/java/net/sf/flatpack/util/ParserUtils.java
@@ -435,7 +435,24 @@ public final class ParserUtils {
                 // remember we are working are way backwards on the line
                 if (qualiFound) {
                     if (chrArry[i] == delimiter) {
-                        return true;
+                        // before deciding if this is the begining of a qualified new line
+                        // I think we have to go back to the beginning of the line and see if we are inside a qualified
+                        // field or not?
+                        //return true;
+                        boolean qualifiedContent = chrArry[0] == qualifier;
+                        for(int index = 0; index < chrArry.length; index++) {
+                            char currentChar = chrArry[index];
+                            qualifiedContent = currentChar == qualifier;
+                            if(qualifiedContent) {
+                                // go until first occurence of closing qualifierdelimiter combination
+                                for(; index < chrArry.length; index++) {
+                                    if(chrArry[index] == delimiter && chrArry[++index] == qualifier) {
+                                        qualifiedContent = false;
+                                    }
+                                }
+                            }
+                        }
+                        return qualifiedContent;
                     }
                     // guard against multiple qualifiers in the sequence [ ,""We ]
                     qualiFound = chrArry[i] == qualifier;
@@ -472,7 +489,24 @@ public final class ParserUtils {
                     continue;
                 }
                 if (chrArry[i] == delimiter) {
-                    return true;
+                        // before deciding if this is the begining of a qualified new line
+                        // I think we have to go back to the beginning of the line and see if we are inside a qualified
+                        // field or not?
+                        //return true;
+                        boolean qualifiedContent = chrArry[0] == qualifier;
+                        for(int index = 0; index < chrArry.length; index++) {
+                            char currentChar = chrArry[index];
+                            qualifiedContent = currentChar == qualifier;
+                            if(qualifiedContent) {
+                                // go until first occurence of closing qualifierdelimiter combination
+                                for(; index < chrArry.length; index++) {
+                                    if(chrArry[index] == delimiter && chrArry[++index] == qualifier) {
+                                        qualifiedContent = false;
+                                    }
+                                }
+                            }
+                        }
+                        return qualifiedContent;
                 }
                 break;
             }

--- a/flatpack/src/test/java/net/sf/flatpack/parserutils/ParserUtilsTest.java
+++ b/flatpack/src/test/java/net/sf/flatpack/parserutils/ParserUtilsTest.java
@@ -63,6 +63,29 @@ public class ParserUtilsTest extends TestCase {
         assertEquals("list should be empty and is not...", ParserUtils.isListElementsEmpty(l), true);
     }
 
+    public void testQualifiedNonMultiLine() {
+        final String data = "data 1-1,data 1-2,\"qualified,data 1-3,\"\n";
+         assertEquals(ParserUtils.isMultiLine(data.toCharArray(), ',', '\"'), false);
+    }
+
+    public void testQualifiedMultiLine() {
+        final String data = "data 1-1,data 1-2,\"qualified,data 1-3,\n" +
+                            "qualified data 1-3 continued from previous line\"\n";
+         assertEquals(ParserUtils.isMultiLine(data.toCharArray(), ',', '\"'), true);
+    }
+
+    public void testNonQualifiedNonMultiLine() {
+        final String data = "data 1-1,data 1-2,qualified,data 1-3\n";
+         assertEquals(ParserUtils.isMultiLine(data.toCharArray(), ',', '\"'), false);
+    }
+
+    public void testNonQualifiedMultiLine() {
+        // can't really have multiline without qualifier
+        final String data = "data 1-1,data 1-2,qualified,data 1-3\n" +
+                            "qualified data 1-3 continued from previous line\n";
+         assertEquals(ParserUtils.isMultiLine(data.toCharArray(), ',', '\"'), false);
+    }
+
     public static void main(final String[] args) {
         junit.textui.TestRunner.run(ParserUtilsTest.class);
     }


### PR DESCRIPTION
Modified ParserUtils to check whether {delimiter}{qualifer} combination at the end of line is the the beginning of a new multiline field or whether it is the end of a qualified field at the end of the line.

The new logic goes back to the beginning of a line when the {delimiter}{qualifier} combination is encountered at the end of a line. The line is then parsed forward checking if the data being parsed is part of a qualified context i.e. a qualifier has occurred but no closing qualifier has been encountered. 

If the final characters are the {delimiter}{qualifer} pair and they are in a qualified context, the delimiter is considered just another piece of data with the qualifier ending the field (and record). Otherwise they are interpreted as the ending of a field and the beginning of a new, qualified multiline field.

Added tests to ParserUtilsTest to confirm the new functionality