### PR TITLE
Upgrade project lombok to 1.18.20 and BND to 5.1.2 in order to compile in Java 16

### DIFF
--- a/flatpack-excel/pom.xml
+++ b/flatpack-excel/pom.xml
@@ -38,7 +38,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>4.1.0</version>
+                <version>5.1.2</version>
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>

--- a/flatpack-samples/pom.xml
+++ b/flatpack-samples/pom.xml
@@ -13,7 +13,7 @@
     <name>FlatPack Examples</name>
     <packaging>bundle</packaging> <!-- (1) OSGi -->
 
-    <description>Examples to handle CSV, Excel CSV, Tab, Pipe delimiters, just to name a few. 
+    <description>Examples to handle CSV, Excel CSV, Tab, Pipe delimiters, just to name a few.
        Maps column positions in the file to user friendly names via XML. See FlatPack Feature List under News for complete feature list.</description>
 
     <properties>
@@ -48,7 +48,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>4.1.0</version>
+                <version>5.1.2</version>
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
@@ -120,7 +120,7 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <!-- 
+    <!--
     <reporting>
         <plugins>
             <plugin>

--- a/flatpack/pom.xml
+++ b/flatpack/pom.xml
@@ -14,7 +14,7 @@
     <name>FlatPack</name>
     <packaging>bundle</packaging> <!-- (1) OSGi -->
 
-    <description>Simple Java delimited and fixed width file parser. Handles CSV, Excel CSV, Tab, Pipe delimiters, just to name a few. 
+    <description>Simple Java delimited and fixed width file parser. Handles CSV, Excel CSV, Tab, Pipe delimiters, just to name a few.
        Maps column positions in the file to user friendly names via XML. See FlatPack Feature List under News for complete feature list.</description>
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>
@@ -40,7 +40,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>4.1.0</version>
+                <version>5.1.2</version>
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
             <dependency>
                 <groupId>org.projectlombok</groupId>
                 <artifactId>lombok</artifactId>
-                <version>1.18.4</version>
+                <version>1.18.20</version>
                 <scope>provided</scope>
             </dependency>
         </dependencies>


### PR DESCRIPTION
Based on the discussion here: https://github.com/Appendium/flatpack/issues/59. Indeed, the issue of compiling in Java 16 and 17EA, it is because of older version of project lombok. Tracing this back to [this issue ](https://github.com/projectlombok/lombok/issues/2681#issuecomment-812288829), Project Lombok version `1.18.20` (latest), should be address the compilation issues under Java 16/17. Also, Maven Bund Plugin (BND), it needed to be upgraded to `5.1.2` in order to support Java 15+ per this issue [here](https://github.com/bndtools/bnd/issues/3903).